### PR TITLE
Remove obsolete AZUREJOBS_EXTENSION_VERSION App Setting

### DIFF
--- a/Source/Apps/Microsoft/Released/Microsoft-TwitterTemplate/Service/AzureArm/function.json
+++ b/Source/Apps/Microsoft/Released/Microsoft-TwitterTemplate/Service/AzureArm/function.json
@@ -52,10 +52,6 @@
               "value": "~0.8"
             },
             {
-              "name": "AZUREJOBS_EXTENSION_VERSION",
-              "value": "beta"
-            },
-            {
               "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
               "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',parameters('storageaccountname'),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageaccountname')), '2015-05-01-preview').key1)]"
             },


### PR DESCRIPTION
This setting is no longer needed and should be removed. It could cause issues going forward.