### PR TITLE
Just check that refresh token is valid, no messing with claims

### DIFF
--- a/Source/Actions/Microsoft.Deployment.Actions.AzureCustom/Common/ConfigureNotifier.cs
+++ b/Source/Actions/Microsoft.Deployment.Actions.AzureCustom/Common/ConfigureNotifier.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Deployment.Actions.AzureCustom.Common
         {
             HttpClient client = new HttpClient();
             client.BaseAddress = new Uri(Constants.ServiceUrl);
-            
+
             dynamic payload = new ExpandoObject();
             payload.tokens = new ExpandoObject();
             payload.tokens.access = accessToken;

--- a/Source/Actions/Microsoft.Deployment.Actions.AzureCustom/CreateSqlConnector.cs
+++ b/Source/Actions/Microsoft.Deployment.Actions.AzureCustom/CreateSqlConnector.cs
@@ -25,8 +25,9 @@ namespace Microsoft.Deployment.Actions.AzureCustom
             var subscription = request.DataStore.GetJson("SelectedSubscription", "SubscriptionId");
             var resourceGroup = request.DataStore.GetValue("SelectedResourceGroup");
             var location = request.DataStore.GetJson("SelectedLocation", "Name");
+            var apiConnectionName = request.DataStore.GetValue("ApiConnectionName");
 
-            var connectionName = request.DataStore.GetValue("ApiConnectionName") == null ? "sql" : request.DataStore.GetValue("ApiConnectionName");
+            var connectionName = apiConnectionName == null ? "sql" : apiConnectionName;
 
             var connectionString = request.DataStore.GetValue("SqlConnectionString");
             var conn = SqlUtility.GetSqlCredentialsFromConnectionString(connectionString);

--- a/Source/Site/Microsoft.Deployment.Site.Service/Controllers/NotifierController.cs
+++ b/Source/Site/Microsoft.Deployment.Site.Service/Controllers/NotifierController.cs
@@ -46,39 +46,23 @@ namespace Microsoft.Deployment.Site.Service.Controllers
                     return resp;
                 }
 
-                var originalClaim = new JwtSecurityToken(accessToken).Claims.First(e => e.Type == "_claim_sources").Value;
 
                 string tokenUrl = string.Format(Constants.AzureTokenUri, "common");
 
-                string newClaim;
-
-                try
-                {
-                    var primaryResponse = await GetToken(refreshToken, tokenUrl, Constants.MicrosoftClientId);
-                    var access = new JwtSecurityToken(primaryResponse["access_token"].ToString());
-                    newClaim = access.Claims.First(e => e.Type == "_claim_sources").Value;
-                }
-                catch
+                var refreshResponse = await GetToken(refreshToken, tokenUrl, Constants.MicrosoftClientId);
+                if (!refreshResponse.IsSuccessStatusCode)
                 {
                     resp = new HttpResponseMessage(HttpStatusCode.Forbidden);
-                    resp.ReasonPhrase = "Access token could not be refreshed, or claim does not exist.";
+                    resp.ReasonPhrase = "Access token could not be refreshed.";
                     return resp;
                 }
 
-                if (originalClaim == newClaim)
-                {
-                    string deploymentIdsConnection = Constants.BpstDeploymentIdDatabase;
-                    var cmd = $"INSERT INTO deploymentids VALUES('{deploymentId}','{DateTime.UtcNow.ToString("o")}')";
-                    SqlUtility.InvokeSqlCommand(deploymentIdsConnection, cmd, new Dictionary<string, string>());
-                }
-                else
-                {
-                    resp = new HttpResponseMessage(HttpStatusCode.Forbidden);
-                    resp.ReasonPhrase = "Claims could not be verified.";
-                    return resp;
-                }
+                string deploymentIdsConnection = Constants.BpstDeploymentIdDatabase;
+                var cmd = $"INSERT INTO deploymentids VALUES('{deploymentId}','{DateTime.UtcNow.ToString("o")}')";
+                SqlUtility.InvokeSqlCommand(deploymentIdsConnection, cmd, new Dictionary<string, string>());
 
-                return new HttpResponseMessage(HttpStatusCode.OK);
+                resp = new HttpResponseMessage(HttpStatusCode.OK);
+                return resp;
             }
             catch
             {
@@ -88,7 +72,7 @@ namespace Microsoft.Deployment.Site.Service.Controllers
             }
         }
 
-        private static async Task<JObject> GetToken(string refreshToken, string tokenUrl, string clientId)
+        private static async Task<HttpResponseMessage> GetToken(string refreshToken, string tokenUrl, string clientId)
         {
             HttpClient client = new HttpClient();
 
@@ -96,9 +80,7 @@ namespace Microsoft.Deployment.Site.Service.Controllers
             var content = new StringContent(builder.ToString());
             content.Headers.ContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
             var response = await client.PostAsync(new Uri(tokenUrl), content);
-
-            var primaryResponse = JsonUtility.GetJsonObjectFromJsonString(response.Content.ReadAsStringAsync().Result);
-            return primaryResponse;
+            return response;
         }
 
         private static StringBuilder GetTokenUri(string refresh_token, string uri, string clientId)


### PR DESCRIPTION
We had been checking to see that _claim_sources was the same in the token and after getting the refresh token, but jwt only sends _claim_sources when there are more than 200 groups. (So not all people had _claim_sources to do a quick double verification on.)