### PR TITLE
T-SQL REPLACE hard size limit

### DIFF
--- a/Source/Apps/Microsoft/Released/Microsoft-NewsTemplate/Service/Database/40 programmability.sql
+++ b/Source/Apps/Microsoft/Released/Microsoft-NewsTemplate/Service/Database/40 programmability.sql
@@ -231,7 +231,7 @@ FROM
 	SELECT [documentId]
       ,[phrase]
 	  ,len(convert(VARCHAR(MAX), t1.cleanedText)) totalLength
-	  ,len(replace(convert(VARCHAR(MAX), t1.cleanedText), phrase, '')) textWithoutPhrase
+	  ,len(replace(convert(VARCHAR(MAX), t1.cleanedText), LEFT(phrase, 1000), '')) textWithoutPhrase
 	  ,len(t0.phrase) phraseLength
 	FROM bpst_news.documentkeyphrases t0
 	INNER JOIN Documents t1 ON t0.documentId = t1.id


### PR DESCRIPTION
When the keyphrase is really long the procedure fails with the following error:

Msg 8152, Level 16, State 10, Line 77
String or binary data would be truncated.

The issue is that the T-SQL REPLACE function has a poorly described limit on the size of the replacement string.  I am attaching a UNICODE file that demonstrates the issue.  The data in the file was pushed through a very similar pipeline and caused this issue.
[replicateTruncationIssue.zip](https://github.com/Microsoft/BusinessPlatformApps/files/1109835/replicateTruncationIssue.zip)

