### PR TITLE
Reddit sort order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,7 @@
 /Function/FacebookUtillity/obj/Release/CoreCompileInputs.cache
 /Functions/Code/Reddit/Src/RedditAzureFunctions/obj
 /Functions/Code/Reddit/Src/RedditCore/obj
+/Functions/Code/Reddit/Src/RedditAzureFunctions/bin/
+/Functions/Code/Reddit/Src/RedditCore/bin/
+/Functions/Code/Reddit/Test/RedditCoreTest/obj/
+/Functions/Code/Reddit/packages/

--- a/Functions/Code/Reddit/Src/RedditAzureFunctions/ExecuteRedditSearch.cs
+++ b/Functions/Code/Reddit/Src/RedditAzureFunctions/ExecuteRedditSearch.cs
@@ -61,6 +61,7 @@ namespace RedditAzureFunctions
                 {
                     threadMatches = socialGist.MatchesForQuery(
                         webConfiguration.QueryTerms,
+                        webConfiguration.QuerySortOrder,
                         null
                     ).Result;
 

--- a/Functions/Code/Reddit/Src/RedditAzureFunctions/WebConfiguration.cs
+++ b/Functions/Code/Reddit/Src/RedditAzureFunctions/WebConfiguration.cs
@@ -48,9 +48,9 @@ namespace RedditAzureFunctions
         /// <summary>
         /// Choices here, from the SocialGist BoardReader API Documentation:
         /// Defines the result sort type. Can be as follows:
-        /// ‘relevance’ (default);
+        /// ‘relevance’;
         /// ‘time_relevance’, sorts by time segments(last hour/day/week/month) in descending order, and then by relevance in descending order; 
-        /// ‘time_desc’, most recent posts first;
+        /// ‘time_desc’, most recent posts first; (default)
         /// ‘time_asc’, oldest posts first.
         /// </summary>
         public string QuerySortOrder => GetOrDefault("QuerySortOrder", "time_desc");

--- a/Functions/Code/Reddit/Src/RedditAzureFunctions/WebConfiguration.cs
+++ b/Functions/Code/Reddit/Src/RedditAzureFunctions/WebConfiguration.cs
@@ -45,6 +45,16 @@ namespace RedditAzureFunctions
         
         public string QueryTerms => ConfigurationManager.AppSettings["QueryTerms"];
 
+        /// <summary>
+        /// Choices here, from the SocialGist BoardReader API Documentation:
+        /// Defines the result sort type. Can be as follows:
+        /// ‘relevance’ (default);
+        /// ‘time_relevance’, sorts by time segments(last hour/day/week/month) in descending order, and then by relevance in descending order; 
+        /// ‘time_desc’, most recent posts first;
+        /// ‘time_asc’, oldest posts first.
+        /// </summary>
+        public string QuerySortOrder => GetOrDefault("QuerySortOrder", "time_desc");
+
         // ReSharper disable once BuiltInTypeReferenceStyle
         public int MaximumResultsPerSearch => int.Parse(ConfigurationManager.AppSettings["MaximumResultsPerSearch"]);
 

--- a/Functions/Code/Reddit/Src/RedditCore/IConfiguration.cs
+++ b/Functions/Code/Reddit/Src/RedditCore/IConfiguration.cs
@@ -20,6 +20,8 @@ namespace RedditCore
 
         string QueryTerms { get; }
 
+        string QuerySortOrder { get; }
+
         // ReSharper disable once BuiltInTypeReferenceStyle
         int MaximumResultsPerSearch { get; }
 

--- a/Functions/Code/Reddit/Src/RedditCore/SocialGist/ISocialGist.cs
+++ b/Functions/Code/Reddit/Src/RedditCore/SocialGist/ISocialGist.cs
@@ -11,6 +11,7 @@ namespace RedditCore.SocialGist
 
         Task<SortedSet<SocialGistPostId>> MatchesForQuery(
             string query,
+            string sortMode,
             long? startUnixTime = null
         );
 

--- a/Functions/Code/Reddit/Src/RedditCore/SocialGist/SocialGist.cs
+++ b/Functions/Code/Reddit/Src/RedditCore/SocialGist/SocialGist.cs
@@ -103,6 +103,7 @@ namespace RedditCore.SocialGist
 
         public async Task<SortedSet<SocialGistPostId>> MatchesForQuery(
             string query,
+            string sortMode,
             long? startUnixTime = null
         )
         {
@@ -111,7 +112,7 @@ namespace RedditCore.SocialGist
             var parameters = GetBaseParameters();
             parameters.Add("query", query);
             parameters.Add("dn", "reddit.com");
-            parameters.Add("sort_mode", "time_desc");
+            parameters.Add("sort_mode", sortMode);
             parameters.Add("keep_original", "true");
             parameters.Add("group_mode", "thread");
             parameters.Add("match_mode", "boolean");

--- a/Functions/Code/Reddit/Src/RedditCore/SocialGist/SocialGist.cs
+++ b/Functions/Code/Reddit/Src/RedditCore/SocialGist/SocialGist.cs
@@ -9,6 +9,7 @@ using System;
 using System.Text;
 using RedditCore.Http;
 using RedditCore.Telemetry;
+using System.Linq;
 
 namespace RedditCore.SocialGist
 {
@@ -54,7 +55,8 @@ namespace RedditCore.SocialGist
             parameters.Add("use_compression", true);
 
             var baseUrl = "http://redditcomments.socialgist.com/";
-            log.Info($"Request to: {baseUrl} with initial parameters: {parameters}.");
+            var paramMessage = string.Join(",", parameters.Select(kvp => kvp.Key + ": " + kvp.Value.ToString()));
+            log.Info($"Request to: {baseUrl} with initial parameters: {paramMessage}.");
 
             var uriBuilder = new UriBuilder(baseUrl);
             uriBuilder.QueryParamsFromDictionary(parameters);
@@ -123,7 +125,9 @@ namespace RedditCore.SocialGist
             var threadIdSet = new SortedSet<SocialGistPostId>();
 
             var baseUrl = "https://redditapi.socialgist.com/v1/Boards/Search";
-            log.Info($"Request to: {baseUrl} with initial parameters: {parameters}.");
+            var paramMessage = string.Join(",", parameters.Select(kvp => kvp.Key + ": " + kvp.Value.ToString()));
+
+            log.Info($"Request to: {baseUrl} with initial parameters: {paramMessage}.");
 
             var resultList = await paginator.PageThroughCallResults<SearchApiResponse, SearchResponse, SearchMatches, SearchMatch>(
                 baseUrl,

--- a/Functions/Code/Reddit/Src/RedditCore/SocialGist/SocialGist.cs
+++ b/Functions/Code/Reddit/Src/RedditCore/SocialGist/SocialGist.cs
@@ -53,7 +53,10 @@ namespace RedditCore.SocialGist
             parameters.Add("url", post.Url);
             parameters.Add("use_compression", true);
 
-            var uriBuilder = new UriBuilder("http://redditcomments.socialgist.com/");
+            var baseUrl = "http://redditcomments.socialgist.com/";
+            log.Info($"Request to: {baseUrl} with initial parameters: {parameters}.");
+
+            var uriBuilder = new UriBuilder(baseUrl);
             uriBuilder.QueryParamsFromDictionary(parameters);
 
             var result =
@@ -119,8 +122,11 @@ namespace RedditCore.SocialGist
 
             var threadIdSet = new SortedSet<SocialGistPostId>();
 
+            var baseUrl = "https://redditapi.socialgist.com/v1/Boards/Search";
+            log.Info($"Request to: {baseUrl} with initial parameters: {parameters}.");
+
             var resultList = await paginator.PageThroughCallResults<SearchApiResponse, SearchResponse, SearchMatches, SearchMatch>(
-                "https://redditapi.socialgist.com/v1/Boards/Search",
+                baseUrl,
                 parameters,
                 ResultLimitPerPage
             );

--- a/Functions/Code/Reddit/Test/RedditCoreTest/SocialGist/SocialGistTest.cs
+++ b/Functions/Code/Reddit/Test/RedditCoreTest/SocialGist/SocialGistTest.cs
@@ -62,7 +62,7 @@ namespace RedditCoreTest.SocialGist
                 socialGist.ResultLimitPerPage
             )).ReturnsAsync(expected);
 
-            var threadIdSet = await socialGist.MatchesForQuery("frogs", null);
+            var threadIdSet = await socialGist.MatchesForQuery("frogs", "time_desc", null);
 
             CollectionAssert.AreEquivalent(threadIdSet, new SortedSet<SocialGistPostId>()
             {

--- a/Source/Apps/Microsoft/Released/Microsoft-RedditTemplate/init.json
+++ b/Source/Apps/Microsoft/Released/Microsoft-RedditTemplate/init.json
@@ -140,7 +140,7 @@
                 "FunctionName": "$save('redditfunction' + this.MS.DataStore.getValue('uniqueId'))",
                 "name": "Microsoft-DeployAzureFunction",
                 "RepoUrl": "https://github.com/dwaynepryce/RedditAzureFunctions.git",
-                "Branch": "release/0.8.x"
+                "Branch": "release/0.9.x"
             },
             {
                 "DeploymentName": "Function",


### PR DESCRIPTION
This PR is primarily for Reddit; they wish to give demonstrations that show what it a PowerBI solution for Reddit would look like if it had been running for months.  Our actual function does things by time_desc, which means we generally have a huge hotspot of data over a single day.  Given that these should be running for quite some time to build up that data for BI purposes, that is acceptable, but it looks very bare and boring when you try to give a demonstration the day you create the template.

This should have no functional change for the average user.  However, individuals could go into their the reddit function App Settings and add a parameter for QuerySortOrder and make it "relevance" and get results based on Socialgists' relevance score vs. solely based on time.