### PR TITLE
OAuthController.cls (SameSite attribute)

### DIFF
--- a/Samples/Salesforce/EmbedPowerBIReport/Classes/OAuthController.cls
+++ b/Samples/Salesforce/EmbedPowerBIReport/Classes/OAuthController.cls
@@ -123,8 +123,8 @@ public virtual class OAuthController {
     * @return The oauth result
     */
     public PageReference refreshAccessToken(PageReference location){
-        Cookie accessToken = new Cookie('pbi_AccessToken', '',null,0,false);
-        Cookie expiresOn = new Cookie('pbi_ExpiresOn','',null,0,false);
+        Cookie accessToken = New Cookie('pbi_AccessToken', '',null,0,true /*isSecure*/,'None' /*SameSite*/);
+        Cookie expiresOn = New Cookie('pbi_ExpiresOn','',null,0,true /*isSecure*/,'None' /*SameSite*/);
             
         ApexPages.currentPage().setCookies(new Cookie[]{accessToken,expiresOn}); 
             
@@ -156,9 +156,9 @@ public virtual class OAuthController {
 
         OAuthResult result = (OAuthResult)(JSON.deserialize(res.getBody(), OAuthResult.class));
         
-        Cookie refreshTokenCookie = new Cookie('pbi_RefreshToken', result.refresh_token,null,-1,false);        
-        accessToken = new Cookie('pbi_AccessToken', result.access_token,null,-1,false);
-        expiresOn = new Cookie('pbi_ExpiresOn',result.expires_on,null,-1,false);
+        Cookie refreshTokenCookie = New Cookie('pbi_RefreshToken', result.refresh_token,null,-1,true /*isSecure*/,'None' /*SameSite*/);        
+        accessToken = New Cookie('pbi_AccessToken', result.access_token,null,-1,true /*isSecure*/,'None' /*SameSite*/);
+        expiresOn = New Cookie('pbi_ExpiresOn',result.expires_on,null,-1,true /*isSecure*/,'None' /*SameSite*/);
         
         ApexPages.currentPage().setCookies(new Cookie[]{accessToken,refreshTokenCookie,expiresOn});   
             
@@ -238,9 +238,9 @@ public virtual class OAuthController {
             OAuthResult result = validateCode(code, this.getPageUrl());
                                    
             //Store accesstoken in cookie
-            Cookie accessToken = new Cookie('pbi_AccessToken', result.access_token,null,-1,false);
-            Cookie refreshToken = new Cookie('pbi_RefreshToken', result.refresh_token,null,-1,false);
-            Cookie expiresOn = new Cookie('pbi_ExpiresOn',result.expires_on,null,-1,false);
+            Cookie accessToken = New Cookie('pbi_AccessToken', result.access_token,null,-1,true /*isSecure*/,'None' /*SameSite*/);
+            Cookie refreshToken = New Cookie('pbi_RefreshToken', result.refresh_token,null,-1,true /*isSecure*/,'None' /*SameSite*/);
+            Cookie expiresOn = New Cookie('pbi_ExpiresOn',result.expires_on,null,-1,true /*isSecure*/,'None' /*SameSite*/);
             
             ApexPages.currentPage().setCookies(new Cookie[]{accessToken,refreshToken,expiresOn}); 
 

--- a/Samples/Salesforce/UsingPowerBIGroupsAndReports/Classes/OAuthController.cls
+++ b/Samples/Salesforce/UsingPowerBIGroupsAndReports/Classes/OAuthController.cls
@@ -125,7 +125,7 @@ public virtual class OAuthController {
         app.Token_Expires_On__c = null;
         update app;
             
-		Cookie accessToken = new Cookie('pbi_AccessToken', '',null,0,false);
+		Cookie accessToken = new Cookie('pbi_AccessToken', '',null,0,true /*isSecure*/,'None' /*SameSite*/);
         ApexPages.currentPage().setCookies(new Cookie[]{accessToken});
             
         String client_id = OAuthApp_pbi__c.getValues(this.application_name).Client_Id__c;
@@ -161,8 +161,8 @@ public virtual class OAuthController {
         
         OAuthResult result = (OAuthResult)(JSON.deserialize(res.getBody(), OAuthResult.class));
         
-        accessToken = new Cookie('pbi_AccessToken', result.access_token,null,-1,false);
-        Cookie refreshTokenCookie = new Cookie('pbi_RefreshToken', result.refresh_token,null,-1,false);
+        accessToken = new Cookie('pbi_AccessToken', result.access_token,null,-1,true /*isSecure*/,'None' /*SameSite*/);
+        Cookie refreshTokenCookie = new Cookie('pbi_RefreshToken', result.refresh_token,null,-1,true /*isSecure*/,'None' /*SameSite*/);
 
         ApexPages.currentPage().setCookies(new Cookie[]{accessToken,refreshTokenCookie});   
         
@@ -249,8 +249,8 @@ public virtual class OAuthController {
             OAuthResult result = validateCode(code, this.getPageUrl());
                                    
             //Store accesstoken in cookie
-            Cookie accessToken = new Cookie('pbi_AccessToken', result.access_token,null,-1,false);
-            Cookie refreshToken = new Cookie('pbi_RefreshToken', result.refresh_token,null,-1,false);
+            Cookie accessToken = new Cookie('pbi_AccessToken', result.access_token,null,-1,true /*isSecure*/,'None' /*SameSite*/);
+            Cookie refreshToken = new Cookie('pbi_RefreshToken', result.refresh_token,null,-1,true /*isSecure*/,'None' /*SameSite*/);
  
             ApexPages.currentPage().setCookies(new Cookie[]{accessToken,refreshToken}); 
             


### PR DESCRIPTION
Fixing the OAuthController Apex classes in order to include the isSecure and SameSite attributes in the cookie(s) instantiation, to allow the code to work properly on the most recent Chrome browser versions(>=85).

More info:
https://www.chromestatus.com/feature/5088147346030592
https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_sites_cookie.htm#apex_System_Cookie_constructors